### PR TITLE
Ship dependencies

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,7 +8,7 @@ documentation/
 examples/
 !LICENSE.txt
 **/*.map
-node_modules/
+#node_modules/
 out/**/*.test.js
 out/test/*
 scripts/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,7 +8,6 @@ documentation/
 examples/
 !LICENSE.txt
 **/*.map
-#node_modules/
 out/**/*.test.js
 out/test/*
 scripts/


### PR DESCRIPTION
VSCode doesn't run `npm i` when installing extensions so we have to bundle the needed dependencies.